### PR TITLE
OCLP Boot Fan Control — apply fan settings before login

### DIFF
--- a/Classes/FanControl.m
+++ b/Classes/FanControl.m
@@ -25,6 +25,7 @@
 #import "FanControl.h"
 #import "MachineDefaults.h"
 #import "SleepWakeFix.h"
+#import "OCLPHelper.h"
 #import <Security/Authorization.h>
 #import <Security/AuthorizationDB.h>
 #import <Security/AuthorizationTags.h>
@@ -216,6 +217,8 @@ NSUserDefaults *defaults;
 	[faqText replaceCharactersInRange:NSMakeRange(0,0) withRTF: [NSData dataWithContentsOfFile:[[NSBundle mainBundle] pathForResource:@"F.A.Q" ofType:@"rtf"]]];
 	// Apply saved per-fan RPM settings (replaces old favorites-based apply)
 	[self applyPerFanSettings];
+	// Check for OCLP and prompt for boot daemon on first launch
+	[OCLPHelper checkAndPromptForDaemonInstall];
 	[[sliderCell dataCell] setControlSize:NSControlSizeSmall];
 	[self changeMenu:nil];
 	
@@ -564,6 +567,9 @@ NSUserDefaults *defaults;
     // Persist to NSUserDefaults
     NSString *prefKey = [NSString stringWithFormat:@"fan_%d_min_rpm", fanIndex];
     [[NSUserDefaults standardUserDefaults] setInteger:newRPM forKey:prefKey];
+
+    // Sync to boot daemon plist so next boot uses updated settings
+    [OCLPHelper syncFanSettingsWithDaemon];
 }
 
 /// Apply saved per-fan minimum RPM values to SMC (used on launch and wake).
@@ -893,6 +899,7 @@ NSUserDefaults *defaults;
 	[defaults synchronize];
 	[mainwindow close];
 	[self applyPerFanSettings];
+	[OCLPHelper syncFanSettingsWithDaemon];
 	undo_dic=[NSDictionary dictionaryWithDictionary:[defaults dictionaryRepresentation]];
 }
 

--- a/Classes/OCLPHelper.h
+++ b/Classes/OCLPHelper.h
@@ -1,0 +1,46 @@
+/*
+ * smcFanControl Community Edition - OCLP Helper
+ *
+ * Provides OCLP detection and boot daemon management for the main app.
+ *
+ * Copyright (c) 2024 wolffcatskyy
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ */
+
+#import <Foundation/Foundation.h>
+
+/// Manages OCLP detection and boot daemon installation for smcFanControl.
+@interface OCLPHelper : NSObject
+
+/// Returns YES if this Mac is running OpenCore Legacy Patcher.
++ (BOOL)isOCLPMac;
+
+/// Returns a human-readable description of how OCLP was detected.
++ (NSString *)oclpDetectionDescription;
+
+/// Returns YES if the boot daemon is currently installed.
++ (BOOL)isDaemonInstalled;
+
+/// Install the boot daemon (requires admin privileges).
+/// Shows an authorization dialog if needed.
+/// Returns YES on success.
++ (BOOL)installDaemon;
+
+/// Uninstall the boot daemon (requires admin privileges).
+/// Returns YES on success.
++ (BOOL)uninstallDaemon;
+
+/// Write current fan settings to the system-level plist that the boot
+/// daemon reads. Called whenever the user changes fan settings in the app.
+/// Returns YES on success.
++ (BOOL)syncFanSettingsWithDaemon;
+
+/// Check OCLP status on first launch and prompt user to install daemon.
+/// Call this from applicationDidFinishLaunching or awakeFromNib.
++ (void)checkAndPromptForDaemonInstall;
+
+@end

--- a/Classes/OCLPHelper.m
+++ b/Classes/OCLPHelper.m
@@ -1,0 +1,376 @@
+/*
+ * smcFanControl Community Edition - OCLP Helper
+ *
+ * Provides OCLP detection and boot daemon management for the main app.
+ * This bridges the C-level OCLP detection to the Objective-C app and
+ * handles privileged installation of the LaunchDaemon.
+ *
+ * Copyright (c) 2024 wolffcatskyy
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ */
+
+#import "OCLPHelper.h"
+#import "smcWrapper.h"
+#import "Constants.h"
+#import <Security/Authorization.h>
+#import <Security/AuthorizationTags.h>
+
+/* Paths */
+static NSString * const kDaemonBinaryInstallPath = @"/Library/Application Support/smcFanControl/smcfancontrold";
+static NSString * const kDaemonPlistInstallPath  = @"/Library/LaunchDaemons/com.smcfancontrol.bootdaemon.plist";
+static NSString * const kFanSettingsPlistPath     = @"/Library/Application Support/smcFanControl/fan-settings.plist";
+static NSString * const kSupportDirPath           = @"/Library/Application Support/smcFanControl";
+
+/* NSUserDefaults keys for tracking OCLP prompts */
+static NSString * const kOCLPPromptShown  = @"OCLPDaemonPromptShown";
+static NSString * const kOCLPDaemonEnabled = @"OCLPDaemonEnabled";
+
+@implementation OCLPHelper
+
+#pragma mark - OCLP Detection
+
++ (BOOL)isOCLPMac {
+    // Check multiple OCLP indicators
+    NSFileManager *fm = [NSFileManager defaultManager];
+    BOOL isDir;
+
+    // Method 1: /Library/OpenCore directory
+    if ([fm fileExistsAtPath:@"/Library/OpenCore" isDirectory:&isDir] && isDir) {
+        return YES;
+    }
+
+    // Method 2: NVRAM opencore-version key
+    NSTask *task = [[NSTask alloc] init];
+    [task setLaunchPath:@"/usr/sbin/nvram"];
+    [task setArguments:@[@"4D1FDA02-38C7-4A6A-9CC6-4BCCA8B30102:opencore-version"]];
+    [task setStandardOutput:[NSPipe pipe]];
+    [task setStandardError:[NSPipe pipe]];
+    @try {
+        [task launch];
+        [task waitUntilExit];
+        if ([task terminationStatus] == 0) return YES;
+    } @catch (NSException *e) {
+        // nvram not available, skip
+    }
+
+    // Method 3: Dortania support directory
+    if ([fm fileExistsAtPath:@"/Library/Application Support/Dortania" isDirectory:&isDir] && isDir) {
+        return YES;
+    }
+
+    // Method 4: boot-args containing OpenCore signatures
+    NSTask *bootTask = [[NSTask alloc] init];
+    [bootTask setLaunchPath:@"/usr/sbin/nvram"];
+    [bootTask setArguments:@[@"boot-args"]];
+    NSPipe *pipe = [NSPipe pipe];
+    [bootTask setStandardOutput:pipe];
+    [bootTask setStandardError:[NSPipe pipe]];
+    @try {
+        [bootTask launch];
+        [bootTask waitUntilExit];
+        if ([bootTask terminationStatus] == 0) {
+            NSData *data = [[pipe fileHandleForReading] readDataToEndOfFile];
+            NSString *output = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
+            if ([output containsString:@"amfi_get_out_of_my_way"] ||
+                [output containsString:@"ipc_control_port_options"] ||
+                [output containsString:@"-lilubetaall"] ||
+                [output containsString:@"revpatch="] ||
+                [output containsString:@"revblock="]) {
+                return YES;
+            }
+        }
+    } @catch (NSException *e) {
+        // Skip
+    }
+
+    return NO;
+}
+
++ (NSString *)oclpDetectionDescription {
+    NSMutableArray *methods = [NSMutableArray array];
+    NSFileManager *fm = [NSFileManager defaultManager];
+    BOOL isDir;
+
+    if ([fm fileExistsAtPath:@"/Library/OpenCore" isDirectory:&isDir] && isDir)
+        [methods addObject:@"/Library/OpenCore"];
+
+    if ([fm fileExistsAtPath:@"/Library/Application Support/Dortania" isDirectory:&isDir] && isDir)
+        [methods addObject:@"Dortania directory"];
+
+    // NVRAM check
+    NSTask *task = [[NSTask alloc] init];
+    [task setLaunchPath:@"/usr/sbin/nvram"];
+    [task setArguments:@[@"4D1FDA02-38C7-4A6A-9CC6-4BCCA8B30102:opencore-version"]];
+    [task setStandardOutput:[NSPipe pipe]];
+    [task setStandardError:[NSPipe pipe]];
+    @try {
+        [task launch];
+        [task waitUntilExit];
+        if ([task terminationStatus] == 0)
+            [methods addObject:@"NVRAM opencore-version"];
+    } @catch (NSException *e) {}
+
+    if ([methods count] == 0) {
+        return @"No OCLP detected";
+    }
+    return [NSString stringWithFormat:@"OCLP detected via: %@", [methods componentsJoinedByString:@", "]];
+}
+
+#pragma mark - Daemon Management
+
++ (BOOL)isDaemonInstalled {
+    NSFileManager *fm = [NSFileManager defaultManager];
+    return [fm fileExistsAtPath:kDaemonBinaryInstallPath] &&
+           [fm fileExistsAtPath:kDaemonPlistInstallPath];
+}
+
++ (BOOL)installDaemon {
+    // The daemon binary is bundled in the app's Resources
+    NSString *bundledBinary = [[NSBundle mainBundle] pathForResource:@"smcfancontrold" ofType:@""];
+    NSString *bundledPlist = [[NSBundle mainBundle] pathForResource:@"com.smcfancontrol.bootdaemon" ofType:@"plist"];
+
+    if (!bundledBinary || !bundledPlist) {
+        NSLog(@"OCLPHelper: daemon binary or plist not found in bundle");
+        return NO;
+    }
+
+    // Create a shell script that performs the privileged installation
+    NSString *script = [NSString stringWithFormat:
+        @"mkdir -p '%@' && "
+         "cp '%@' '%@' && "
+         "chmod 755 '%@' && "
+         "chown root:wheel '%@' && "
+         "cp '%@' '%@' && "
+         "chmod 644 '%@' && "
+         "chown root:wheel '%@' && "
+         "launchctl load '%@' 2>/dev/null; true",
+        kSupportDirPath,
+        bundledBinary, kDaemonBinaryInstallPath,
+        kDaemonBinaryInstallPath,
+        kDaemonBinaryInstallPath,
+        bundledPlist, kDaemonPlistInstallPath,
+        kDaemonPlistInstallPath,
+        kDaemonPlistInstallPath,
+        kDaemonPlistInstallPath
+    ];
+
+    BOOL success = [self runPrivilegedScript:script];
+    if (success) {
+        [[NSUserDefaults standardUserDefaults] setBool:YES forKey:kOCLPDaemonEnabled];
+        // Sync current fan settings so the daemon has something to apply
+        [self syncFanSettingsWithDaemon];
+        NSLog(@"OCLPHelper: daemon installed successfully");
+    }
+    return success;
+}
+
++ (BOOL)uninstallDaemon {
+    NSString *script = [NSString stringWithFormat:
+        @"launchctl unload '%@' 2>/dev/null; "
+         "rm -f '%@' '%@'",
+        kDaemonPlistInstallPath,
+        kDaemonPlistInstallPath,
+        kDaemonBinaryInstallPath
+    ];
+
+    BOOL success = [self runPrivilegedScript:script];
+    if (success) {
+        [[NSUserDefaults standardUserDefaults] setBool:NO forKey:kOCLPDaemonEnabled];
+        NSLog(@"OCLPHelper: daemon uninstalled successfully");
+    }
+    return success;
+}
+
+#pragma mark - Fan Settings Sync
+
++ (BOOL)syncFanSettingsWithDaemon {
+    if (![self isDaemonInstalled]) return NO;
+
+    // Build the fan settings plist from current NSUserDefaults
+    int numFans = [smcWrapper get_fan_num];
+    NSMutableArray *fansArray = [NSMutableArray array];
+
+    for (int i = 0; i < numFans; i++) {
+        NSString *prefKey = [NSString stringWithFormat:@"fan_%d_min_rpm", i];
+        int savedRPM = (int)[[NSUserDefaults standardUserDefaults] integerForKey:prefKey];
+
+        // Validate against hardware limits
+        int hwMin = [smcWrapper get_min_speed:i];
+        int hwMax = [smcWrapper get_max_speed:i];
+        if (hwMin <= 0) hwMin = 800;
+        if (hwMax <= hwMin) hwMax = hwMin + 4000;
+        if (savedRPM < hwMin || savedRPM > hwMax) savedRPM = hwMin;
+
+        [fansArray addObject:@{
+            @"id": @(i),
+            @"min_rpm": @(savedRPM)
+        }];
+    }
+
+    NSDictionary *plistDict = @{ @"fans": fansArray };
+
+    // Write to a temp file first, then move with privileges
+    NSString *tmpPath = [NSTemporaryDirectory() stringByAppendingPathComponent:@"smcfc-fan-settings.plist"];
+    BOOL wrote = [plistDict writeToFile:tmpPath atomically:YES];
+    if (!wrote) {
+        NSLog(@"OCLPHelper: failed to write temp fan-settings plist");
+        return NO;
+    }
+
+    // Copy with admin privileges to the system location
+    NSString *script = [NSString stringWithFormat:
+        @"mkdir -p '%@' && cp '%@' '%@' && chmod 644 '%@'",
+        kSupportDirPath, tmpPath, kFanSettingsPlistPath, kFanSettingsPlistPath
+    ];
+
+    BOOL success = [self runPrivilegedScript:script];
+    [[NSFileManager defaultManager] removeItemAtPath:tmpPath error:nil];
+
+    if (success) {
+        NSLog(@"OCLPHelper: fan settings synced to %@", kFanSettingsPlistPath);
+    }
+    return success;
+}
+
+#pragma mark - First-Launch Prompt
+
++ (void)checkAndPromptForDaemonInstall {
+    // Only prompt once
+    if ([[NSUserDefaults standardUserDefaults] boolForKey:kOCLPPromptShown]) return;
+
+    // Only prompt on OCLP Macs
+    if (![self isOCLPMac]) return;
+
+    [[NSUserDefaults standardUserDefaults] setBool:YES forKey:kOCLPPromptShown];
+
+    // Delay slightly so the app finishes launching first
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(2.0 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+        NSAlert *alert = [[NSAlert alloc] init];
+        [alert setMessageText:@"OCLP Mac Detected"];
+        [alert setInformativeText:
+            @"Your Mac is running OpenCore Legacy Patcher. On OCLP Macs, "
+             "fans run at full speed until smcFanControl starts.\n\n"
+             "Would you like to enable boot-time fan control? This installs "
+             "a small system daemon that applies your fan settings immediately "
+             "at boot, before you even log in.\n\n"
+             "You can change this later in Preferences."];
+        [alert setAlertStyle:NSAlertStyleInformational];
+        [alert addButtonWithTitle:@"Enable Boot Fan Control"];
+        [alert addButtonWithTitle:@"Not Now"];
+
+        if (@available(macOS 11.0, *)) {
+            // Use SF Symbol for the icon if available
+            NSImage *icon = [NSImage imageWithSystemSymbolName:@"fan.floor"
+                                     accessibilityDescription:@"Fan"];
+            if (icon) [alert setIcon:icon];
+        }
+
+        NSModalResponse response = [alert runModal];
+        if (response == NSAlertFirstButtonReturn) {
+            BOOL installed = [OCLPHelper installDaemon];
+            if (installed) {
+                NSAlert *successAlert = [[NSAlert alloc] init];
+                [successAlert setMessageText:@"Boot Fan Control Enabled"];
+                [successAlert setInformativeText:
+                    @"The fan control daemon has been installed. Your fan "
+                     "settings will now be applied at boot before login.\n\n"
+                     "The daemon reads from:\n"
+                     "/Library/Application Support/smcFanControl/fan-settings.plist\n\n"
+                     "Settings are synced automatically when you adjust fan speeds."];
+                [successAlert setAlertStyle:NSAlertStyleInformational];
+                [successAlert addButtonWithTitle:@"OK"];
+                [successAlert runModal];
+            } else {
+                NSAlert *errorAlert = [[NSAlert alloc] init];
+                [errorAlert setMessageText:@"Installation Failed"];
+                [errorAlert setInformativeText:
+                    @"Could not install the boot fan control daemon. "
+                     "You may need to grant administrator access. "
+                     "You can try again from Preferences."];
+                [errorAlert setAlertStyle:NSAlertStyleWarning];
+                [errorAlert addButtonWithTitle:@"OK"];
+                [errorAlert runModal];
+            }
+        }
+    });
+}
+
+#pragma mark - Privileged Execution
+
++ (BOOL)runPrivilegedScript:(NSString *)script {
+    // Use AuthorizationCreate + /bin/sh to run privileged commands.
+    // This shows the standard macOS admin password dialog.
+    AuthorizationRef authRef = NULL;
+    OSStatus status = AuthorizationCreate(NULL, kAuthorizationEmptyEnvironment,
+                                          kAuthorizationFlagDefaults, &authRef);
+    if (status != errAuthorizationSuccess) {
+        NSLog(@"OCLPHelper: AuthorizationCreate failed: %d", (int)status);
+        return NO;
+    }
+
+    AuthorizationItem authItem = {
+        .name = kAuthorizationRightExecute,
+        .valueLength = 0,
+        .value = NULL,
+        .flags = 0
+    };
+    AuthorizationRights authRights = {
+        .count = 1,
+        .items = &authItem
+    };
+
+    status = AuthorizationCopyRights(authRef, &authRights, kAuthorizationEmptyEnvironment,
+                                     kAuthorizationFlagDefaults |
+                                     kAuthorizationFlagInteractionAllowed |
+                                     kAuthorizationFlagPreAuthorize |
+                                     kAuthorizationFlagExtendRights,
+                                     NULL);
+    if (status != errAuthorizationSuccess) {
+        NSLog(@"OCLPHelper: AuthorizationCopyRights failed: %d", (int)status);
+        AuthorizationFree(authRef, kAuthorizationFlagDefaults);
+        return NO;
+    }
+
+    // Write the script to a temp file and execute it with /bin/sh via STPrivilegedTask pattern
+    NSString *tmpScript = [NSTemporaryDirectory() stringByAppendingPathComponent:@"smcfc-install.sh"];
+    NSError *writeError = nil;
+    [script writeToFile:tmpScript atomically:YES encoding:NSUTF8StringEncoding error:&writeError];
+    if (writeError) {
+        NSLog(@"OCLPHelper: failed to write install script: %@", writeError);
+        AuthorizationFree(authRef, kAuthorizationFlagDefaults);
+        return NO;
+    }
+
+    // Use NSTask with the authorization to run as root
+    // Since AuthorizationExecuteWithPrivileges is deprecated, we use a helper approach:
+    // Write the script and use osascript "do shell script ... with administrator privileges"
+    AuthorizationFree(authRef, kAuthorizationFlagDefaults);
+
+    // Use osascript for privilege escalation (modern macOS compatible approach)
+    NSString *escapedScript = [script stringByReplacingOccurrencesOfString:@"'" withString:@"'\\''"];
+    NSString *osaScript = [NSString stringWithFormat:
+        @"do shell script '%@' with administrator privileges", escapedScript];
+
+    NSTask *task = [[NSTask alloc] init];
+    [task setLaunchPath:@"/usr/bin/osascript"];
+    [task setArguments:@[@"-e", osaScript]];
+    [task setStandardOutput:[NSPipe pipe]];
+    [task setStandardError:[NSPipe pipe]];
+
+    @try {
+        [task launch];
+        [task waitUntilExit];
+        [[NSFileManager defaultManager] removeItemAtPath:tmpScript error:nil];
+        return ([task terminationStatus] == 0);
+    } @catch (NSException *e) {
+        NSLog(@"OCLPHelper: privileged execution failed: %@", e);
+        [[NSFileManager defaultManager] removeItemAtPath:tmpScript error:nil];
+        return NO;
+    }
+}
+
+@end

--- a/FanControlHelper/INTEGRATION.md
+++ b/FanControlHelper/INTEGRATION.md
@@ -1,0 +1,115 @@
+# OCLP Boot Fan Daemon — Integration Guide
+
+## Overview
+
+This adds a LaunchDaemon that applies saved fan minimum RPM settings at boot,
+before the user logs in. This is critical for OCLP (OpenCore Legacy Patcher)
+Macs where the SMC fan controller defaults to maximum speed until software
+sets the minimum RPM.
+
+## Architecture
+
+```
+Boot → launchd loads com.smcfancontrol.bootdaemon.plist
+     → runs /Library/Application Support/smcFanControl/smcfancontrold
+     → detects OCLP (skips if not OCLP, unless forced)
+     → reads /Library/Application Support/smcFanControl/fan-settings.plist
+     → writes F{n}Mn keys to SMC
+     → logs to /var/log/smcfancontrold.log
+     → exits
+```
+
+## Files
+
+### New files (daemon):
+- `FanControlHelper/smcfancontrold.c` — The daemon binary source
+- `FanControlHelper/OCLPDetect.h` — OCLP detection API (C header)
+- `FanControlHelper/OCLPDetect.c` — OCLP detection implementation
+- `FanControlHelper/com.smcfancontrol.bootdaemon.plist` — LaunchDaemon plist
+- `FanControlHelper/fan-settings-example.plist` — Example config
+- `FanControlHelper/Makefile` — Standalone build/install
+
+### New files (app integration):
+- `Classes/OCLPHelper.h` — Objective-C OCLP helper API
+- `Classes/OCLPHelper.m` — OCLP detection, daemon install/uninstall, settings sync
+
+### Modified files:
+- `Classes/FanControl.m` — Added OCLPHelper import, first-launch prompt, settings sync
+
+## Xcode Project Integration
+
+### 1. Add a new target for smcfancontrold
+
+1. In Xcode, File → New → Target → macOS → Command Line Tool
+2. Name: `smcfancontrold`, Language: C
+3. Add these source files to the target:
+   - `FanControlHelper/smcfancontrold.c`
+   - `FanControlHelper/OCLPDetect.c`
+   - `FanControlHelper/OCLPDetect.h`
+4. Link frameworks: `IOKit.framework`, `CoreFoundation.framework`
+5. Build Settings:
+   - `MACOSX_DEPLOYMENT_TARGET` = `10.13`
+   - `GCC_PREPROCESSOR_DEFINITIONS` = (none needed, this is standalone)
+6. Under the main app target → Build Phases → Copy Bundle Resources:
+   - Add the built `smcfancontrold` binary
+   - Add `com.smcfancontrol.bootdaemon.plist`
+7. Add a "Target Dependency" from the main app to `smcfancontrold`
+
+### 2. Add OCLPHelper to the main app target
+
+1. Add `Classes/OCLPHelper.h` and `Classes/OCLPHelper.m` to the smcFanControl target
+2. The `#import "OCLPHelper.h"` is already added to `FanControl.m`
+
+### 3. Build and test
+
+```bash
+# Build daemon standalone
+cd FanControlHelper
+make
+
+# Test OCLP detection (dry run)
+sudo ./smcfancontrold -n
+
+# Test with force flag (non-OCLP Mac)
+sudo ./smcfancontrold -f -c fan-settings-example.plist
+
+# Full install
+sudo make install
+```
+
+## How Settings Flow
+
+1. User adjusts fan slider in smcFanControl.app
+2. `fanSliderChanged:` writes to SMC and saves to NSUserDefaults
+3. `[OCLPHelper syncFanSettingsWithDaemon]` writes to system-level plist
+4. On next boot, `smcfancontrold` reads that plist and applies via SMC
+
+## OCLP Detection Methods
+
+The daemon checks four indicators (any one is sufficient):
+
+| Method | Check | Reliability |
+|--------|-------|-------------|
+| Directory | `/Library/OpenCore` exists | High — OCLP always creates this |
+| NVRAM | `opencore-version` key present | High — set by OpenCore bootloader |
+| Directory | `/Library/Application Support/Dortania` | Medium — OCLP support files |
+| Boot args | `amfi_get_out_of_my_way`, `revpatch=`, etc. | Medium — common OCLP flags |
+
+## Daemon CLI Options
+
+```
+Usage: smcfancontrold [options]
+  -c <path>   Config plist path (default: /Library/Application Support/smcFanControl/fan-settings.plist)
+  -f          Force apply even if OCLP is not detected
+  -n          Dry run (detect OCLP and read config, but don't write SMC)
+  -q          Quiet mode (no log file, stderr only)
+  -h          Show help
+```
+
+## Security Notes
+
+- The daemon runs as root (required for SMC writes)
+- The LaunchDaemon plist must be owned by root:wheel with 644 permissions
+- The daemon binary must be owned by root:wheel with 755 permissions
+- Installation requires admin authentication (shown via standard macOS dialog)
+- The fan-settings.plist is readable by all but only writable with admin privileges

--- a/FanControlHelper/Makefile
+++ b/FanControlHelper/Makefile
@@ -1,0 +1,49 @@
+# smcfancontrold — Boot-time fan control daemon for OCLP Macs
+#
+# Build:   make
+# Install: sudo make install
+# Remove:  sudo make uninstall
+#
+# Requires: macOS SDK with IOKit and CoreFoundation
+
+CC = clang
+CFLAGS = -Wall -Wextra -O2 -mmacosx-version-min=10.13
+LDFLAGS = -framework IOKit -framework CoreFoundation
+
+SOURCES = smcfancontrold.c OCLPDetect.c
+TARGET = smcfancontrold
+
+INSTALL_DIR = /Library/Application Support/smcFanControl
+LAUNCHDAEMONS_DIR = /Library/LaunchDaemons
+PLIST = com.smcfancontrol.bootdaemon.plist
+
+.PHONY: all clean install uninstall
+
+all: $(TARGET)
+
+$(TARGET): $(SOURCES)
+	$(CC) $(CFLAGS) -o $@ $(SOURCES) $(LDFLAGS)
+
+clean:
+	rm -f $(TARGET)
+
+install: $(TARGET)
+	@echo "Installing smcfancontrold..."
+	mkdir -p "$(INSTALL_DIR)"
+	cp $(TARGET) "$(INSTALL_DIR)/$(TARGET)"
+	chmod 755 "$(INSTALL_DIR)/$(TARGET)"
+	chown root:wheel "$(INSTALL_DIR)/$(TARGET)"
+	cp $(PLIST) "$(LAUNCHDAEMONS_DIR)/$(PLIST)"
+	chmod 644 "$(LAUNCHDAEMONS_DIR)/$(PLIST)"
+	chown root:wheel "$(LAUNCHDAEMONS_DIR)/$(PLIST)"
+	@echo "Loading daemon..."
+	launchctl load "$(LAUNCHDAEMONS_DIR)/$(PLIST)" 2>/dev/null || true
+	@echo "Done. The daemon will run at next boot."
+	@echo "To test now: sudo '$(INSTALL_DIR)/$(TARGET)' -f"
+
+uninstall:
+	@echo "Uninstalling smcfancontrold..."
+	launchctl unload "$(LAUNCHDAEMONS_DIR)/$(PLIST)" 2>/dev/null || true
+	rm -f "$(LAUNCHDAEMONS_DIR)/$(PLIST)"
+	rm -f "$(INSTALL_DIR)/$(TARGET)"
+	@echo "Done. Fan settings plist left in place at $(INSTALL_DIR)/fan-settings.plist"

--- a/FanControlHelper/OCLPDetect.c
+++ b/FanControlHelper/OCLPDetect.c
@@ -1,0 +1,113 @@
+/*
+ * smcFanControl Community Edition - OCLP Detection
+ * Detects if the Mac is running OpenCore Legacy Patcher.
+ *
+ * Copyright (c) 2024 wolffcatskyy
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ */
+
+#include "OCLPDetect.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+
+/* Check if a directory exists */
+static bool dir_exists(const char *path)
+{
+    struct stat sb;
+    return (stat(path, &sb) == 0 && S_ISDIR(sb.st_mode));
+}
+
+/* Check NVRAM for OpenCore version key */
+static bool nvram_has_opencore(void)
+{
+    /*
+     * OCLP sets the NVRAM variable:
+     *   4D1FDA02-38C7-4A6A-9CC6-4BCCA8B30102:opencore-version
+     *
+     * We shell out to nvram(8) since IOKit NVRAM access from a
+     * non-privileged context can be tricky. The daemon runs as root
+     * so this is fine.
+     */
+    int ret = system("nvram 4D1FDA02-38C7-4A6A-9CC6-4BCCA8B30102:opencore-version >/dev/null 2>&1");
+    return (ret == 0);
+}
+
+/* Check boot-args for OpenCore signatures */
+static bool bootargs_has_opencore(void)
+{
+    FILE *fp = popen("nvram boot-args 2>/dev/null", "r");
+    if (!fp) return false;
+
+    char buf[1024];
+    bool found = false;
+    while (fgets(buf, sizeof(buf), fp)) {
+        /* Common OCLP boot-args patterns */
+        if (strstr(buf, "amfi_get_out_of_my_way") ||
+            strstr(buf, "ipc_control_port_options") ||
+            strstr(buf, "-lilubetaall") ||
+            strstr(buf, "revpatch=") ||
+            strstr(buf, "revblock=")) {
+            found = true;
+            break;
+        }
+    }
+    pclose(fp);
+    return found;
+}
+
+int oclp_detect(void)
+{
+    int flags = 0;
+
+    /* Method 1: Check for /Library/OpenCore (OCLP installs its files here) */
+    if (dir_exists("/Library/OpenCore")) {
+        flags |= OCLP_METHOD_OPENCORE_DIR;
+    }
+
+    /* Method 2: Check NVRAM for opencore-version key */
+    if (nvram_has_opencore()) {
+        flags |= OCLP_METHOD_NVRAM;
+    }
+
+    /* Method 3: Check for Dortania support directory */
+    if (dir_exists("/Library/Application Support/Dortania")) {
+        flags |= OCLP_METHOD_DORTANIA_DIR;
+    }
+
+    /* Method 4: Check boot-args for OpenCore-related flags */
+    if (bootargs_has_opencore()) {
+        flags |= OCLP_METHOD_BOOTARGS;
+    }
+
+    return flags;
+}
+
+char *oclp_describe(int detection_flags, char *buf, size_t buf_size)
+{
+    if (detection_flags == 0) {
+        snprintf(buf, buf_size, "No OCLP detected");
+        return buf;
+    }
+
+    buf[0] = '\0';
+    size_t offset = 0;
+
+    offset += snprintf(buf + offset, buf_size - offset, "OCLP detected via:");
+
+    if (detection_flags & OCLP_METHOD_OPENCORE_DIR)
+        offset += snprintf(buf + offset, buf_size - offset, " [/Library/OpenCore]");
+    if (detection_flags & OCLP_METHOD_NVRAM)
+        offset += snprintf(buf + offset, buf_size - offset, " [NVRAM opencore-version]");
+    if (detection_flags & OCLP_METHOD_DORTANIA_DIR)
+        offset += snprintf(buf + offset, buf_size - offset, " [Dortania dir]");
+    if (detection_flags & OCLP_METHOD_BOOTARGS)
+        offset += snprintf(buf + offset, buf_size - offset, " [boot-args]");
+
+    return buf;
+}

--- a/FanControlHelper/OCLPDetect.h
+++ b/FanControlHelper/OCLPDetect.h
@@ -1,0 +1,44 @@
+/*
+ * smcFanControl Community Edition - OCLP Detection
+ * Detects if the Mac is running OpenCore Legacy Patcher.
+ *
+ * Copyright (c) 2024 wolffcatskyy
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ */
+
+#ifndef OCLP_DETECT_H
+#define OCLP_DETECT_H
+
+#include <stdbool.h>
+
+/*
+ * OCLP detection methods (bitfield flags for reporting which triggered):
+ *   0x01 = /Library/OpenCore directory exists
+ *   0x02 = NVRAM opencore-version key present
+ *   0x04 = /Library/Application Support/Dortania directory exists
+ *   0x08 = OpenCore boot-args detected
+ */
+#define OCLP_METHOD_OPENCORE_DIR   0x01
+#define OCLP_METHOD_NVRAM          0x02
+#define OCLP_METHOD_DORTANIA_DIR   0x04
+#define OCLP_METHOD_BOOTARGS       0x08
+
+/*
+ * Check if this Mac is running OpenCore Legacy Patcher.
+ *
+ * Returns: bitfield of detection methods that matched, or 0 if not OCLP.
+ *          Any non-zero value means OCLP was detected.
+ */
+int oclp_detect(void);
+
+/*
+ * Human-readable description of detection results.
+ * Writes to the provided buffer. Returns the buffer pointer.
+ */
+char *oclp_describe(int detection_flags, char *buf, size_t buf_size);
+
+#endif /* OCLP_DETECT_H */

--- a/FanControlHelper/com.smcfancontrol.bootdaemon.plist
+++ b/FanControlHelper/com.smcfancontrol.bootdaemon.plist
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.smcfancontrol.bootdaemon</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/Library/Application Support/smcFanControl/smcfancontrold</string>
+    </array>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <false/>
+    <key>StandardErrorPath</key>
+    <string>/var/log/smcfancontrold.log</string>
+    <key>LaunchOnlyOnce</key>
+    <true/>
+</dict>
+</plist>

--- a/FanControlHelper/fan-settings-example.plist
+++ b/FanControlHelper/fan-settings-example.plist
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<!--
+    fan-settings.plist — System-level fan configuration for smcfancontrold.
+
+    This file is written by smcFanControl.app whenever the user changes fan
+    settings, and read by the boot daemon (smcfancontrold) at startup before
+    login. It lives at:
+
+      /Library/Application Support/smcFanControl/fan-settings.plist
+
+    Each entry in the "fans" array specifies:
+      id       — Fan index (0-based, matching SMC F{n}Mn keys)
+      min_rpm  — Minimum RPM to set at boot
+
+    The daemon will only apply these settings on OCLP-patched Macs unless
+    invoked with the -f (force) flag.
+-->
+<dict>
+    <key>fans</key>
+    <array>
+        <dict>
+            <key>id</key>
+            <integer>0</integer>
+            <key>min_rpm</key>
+            <integer>1800</integer>
+        </dict>
+        <dict>
+            <key>id</key>
+            <integer>1</integer>
+            <key>min_rpm</key>
+            <integer>1800</integer>
+        </dict>
+    </array>
+</dict>
+</plist>

--- a/FanControlHelper/smcfancontrold.c
+++ b/FanControlHelper/smcfancontrold.c
@@ -1,0 +1,458 @@
+/*
+ * smcFanControl Community Edition - Boot Fan Daemon (smcfancontrold)
+ *
+ * A short-lived daemon that runs at boot (via LaunchDaemon) to apply
+ * saved fan minimum RPM settings before the user logs in. This is
+ * critical for OCLP (OpenCore Legacy Patcher) Macs where the SMC fan
+ * controller defaults to maximum speed until software intervenes.
+ *
+ * Operation:
+ *   1. Checks if this is an OCLP Mac (optional — can be forced with -f)
+ *   2. Reads fan settings from /Library/Application Support/smcFanControl/fan-settings.plist
+ *   3. Applies fan minimum RPM via SMC writes
+ *   4. Logs results to /var/log/smcfancontrold.log
+ *   5. Exits immediately (not a long-running daemon)
+ *
+ * Based on SMC access code from smcFanControl by Hendrik Holtmann,
+ * original SMC tool by devnull, portions by Michael Wilber.
+ *
+ * Copyright (c) 2024 wolffcatskyy
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include <unistd.h>
+#include <IOKit/IOKitLib.h>
+#include <CoreFoundation/CoreFoundation.h>
+#include "OCLPDetect.h"
+
+/* --- SMC constants and types --- */
+
+#define KERNEL_INDEX_SMC      2
+#define SMC_CMD_READ_BYTES    5
+#define SMC_CMD_WRITE_BYTES   6
+#define SMC_CMD_READ_KEYINFO  9
+
+#define DEFAULT_CONFIG_PATH   "/Library/Application Support/smcFanControl/fan-settings.plist"
+#define LOG_PATH              "/var/log/smcfancontrold.log"
+
+#define MAX_FANS              20
+#define MAX_RPM               10000
+
+typedef unsigned char SMCBytes_t[32];
+typedef char UInt32Char_t[5];
+
+typedef struct {
+    UInt32 dataSize;
+    UInt32 dataType;
+    char   dataAttributes;
+} SMCKeyData_keyInfo_t;
+
+typedef struct {
+    UInt32                key;
+    struct { char major; char minor; char build; char reserved[1]; UInt16 release; } vers;
+    struct { UInt16 version; UInt16 length; UInt32 cpuPLimit; UInt32 gpuPLimit; UInt32 memPLimit; } pLimitData;
+    SMCKeyData_keyInfo_t  keyInfo;
+    char                  result;
+    char                  status;
+    char                  data8;
+    UInt32                data32;
+    SMCBytes_t            bytes;
+} SMCKeyData_t;
+
+typedef struct {
+    UInt32Char_t key;
+    UInt32       dataSize;
+    UInt32Char_t dataType;
+    SMCBytes_t   bytes;
+} SMCVal_t;
+
+/* --- Logging --- */
+
+static FILE *g_logfile = NULL;
+
+static void log_msg(const char *fmt, ...) __attribute__((format(printf, 1, 2)));
+static void log_msg(const char *fmt, ...)
+{
+    time_t now = time(NULL);
+    struct tm *tm = localtime(&now);
+    char timebuf[64];
+    strftime(timebuf, sizeof(timebuf), "%Y-%m-%d %H:%M:%S", tm);
+
+    va_list ap;
+    va_start(ap, fmt);
+
+    /* Write to log file */
+    if (g_logfile) {
+        fprintf(g_logfile, "[%s] ", timebuf);
+        vfprintf(g_logfile, fmt, ap);
+        fprintf(g_logfile, "\n");
+        fflush(g_logfile);
+    }
+
+    va_end(ap);
+
+    /* Also write to stderr (captured by launchd) */
+    va_start(ap, fmt);
+    fprintf(stderr, "smcfancontrold: ");
+    vfprintf(stderr, fmt, ap);
+    fprintf(stderr, "\n");
+    va_end(ap);
+}
+
+/* --- SMC access --- */
+
+static UInt32 key_to_uint32(const char *str)
+{
+    UInt32 total = 0;
+    for (int i = 0; i < 4; i++)
+        total += (unsigned char)str[i] << ((3 - i) * 8);
+    return total;
+}
+
+static void uint32_to_key(char *str, UInt32 val)
+{
+    str[0] = (val >> 24) & 0xFF;
+    str[1] = (val >> 16) & 0xFF;
+    str[2] = (val >> 8)  & 0xFF;
+    str[3] = val & 0xFF;
+    str[4] = '\0';
+}
+
+static kern_return_t smc_call(io_connect_t conn, int index,
+                              SMCKeyData_t *in, SMCKeyData_t *out)
+{
+    size_t in_size = sizeof(SMCKeyData_t);
+    size_t out_size = sizeof(SMCKeyData_t);
+    return IOConnectCallStructMethod(conn, index, in, in_size, out, &out_size);
+}
+
+static kern_return_t smc_open(io_connect_t *conn)
+{
+    kern_return_t result;
+    io_iterator_t iterator;
+    io_object_t device;
+
+    CFMutableDictionaryRef matching = IOServiceMatching("AppleSMC");
+    result = IOServiceGetMatchingServices(kIOMainPortDefault, matching, &iterator);
+    if (result != kIOReturnSuccess) {
+        log_msg("error: IOServiceGetMatchingServices() = 0x%08x", result);
+        return result;
+    }
+
+    device = IOIteratorNext(iterator);
+    IOObjectRelease(iterator);
+    if (device == 0) {
+        log_msg("error: no AppleSMC device found");
+        return kIOReturnNotFound;
+    }
+
+    result = IOServiceOpen(device, mach_task_self(), 0, conn);
+    IOObjectRelease(device);
+    if (result != kIOReturnSuccess)
+        log_msg("error: IOServiceOpen() = 0x%08x", result);
+    return result;
+}
+
+static kern_return_t smc_read(io_connect_t conn, const char *key_str, SMCVal_t *val)
+{
+    kern_return_t result;
+    SMCKeyData_t in, out;
+
+    memset(&in, 0, sizeof(in));
+    memset(&out, 0, sizeof(out));
+    memset(val, 0, sizeof(*val));
+
+    in.key = key_to_uint32(key_str);
+    snprintf(val->key, sizeof(val->key), "%s", key_str);
+
+    in.data8 = SMC_CMD_READ_KEYINFO;
+    result = smc_call(conn, KERNEL_INDEX_SMC, &in, &out);
+    if (result != kIOReturnSuccess) return result;
+
+    val->dataSize = out.keyInfo.dataSize;
+    uint32_to_key(val->dataType, out.keyInfo.dataType);
+
+    in.keyInfo.dataSize = val->dataSize;
+    in.data8 = SMC_CMD_READ_BYTES;
+    memset(&out, 0, sizeof(out));
+    result = smc_call(conn, KERNEL_INDEX_SMC, &in, &out);
+    if (result != kIOReturnSuccess) return result;
+
+    memcpy(val->bytes, out.bytes, sizeof(out.bytes));
+    return kIOReturnSuccess;
+}
+
+static kern_return_t smc_write(io_connect_t conn, const char *key_str,
+                               const unsigned char *data, UInt32 data_size)
+{
+    kern_return_t result;
+    SMCVal_t read_val;
+    SMCKeyData_t in, out;
+
+    result = smc_read(conn, key_str, &read_val);
+    if (result != kIOReturnSuccess) return result;
+
+    if (read_val.dataSize != data_size) {
+        log_msg("error: key %s size mismatch (expected %u, got %u)",
+                key_str, read_val.dataSize, data_size);
+        return kIOReturnBadArgument;
+    }
+
+    memset(&in, 0, sizeof(in));
+    memset(&out, 0, sizeof(out));
+    in.key = key_to_uint32(key_str);
+    in.data8 = SMC_CMD_WRITE_BYTES;
+    in.keyInfo.dataSize = data_size;
+    memcpy(in.bytes, data, data_size);
+
+    return smc_call(conn, KERNEL_INDEX_SMC, &in, &out);
+}
+
+/* Encode RPM as fpe2: value * 4, big-endian 2 bytes */
+static void encode_fpe2(int rpm, unsigned char out[2])
+{
+    UInt16 encoded = (UInt16)(rpm * 4);
+    out[0] = (encoded >> 8) & 0xFF;
+    out[1] = encoded & 0xFF;
+}
+
+/* Decode fpe2 to RPM */
+static float decode_fpe2(const unsigned char bytes[2])
+{
+    UInt16 raw = ((UInt16)bytes[0] << 8) | bytes[1];
+    return raw / 4.0f;
+}
+
+/* --- Plist config loading --- */
+
+static CFDictionaryRef load_config(const char *path)
+{
+    CFURLRef url = CFURLCreateFromFileSystemRepresentation(
+        kCFAllocatorDefault, (const UInt8 *)path, strlen(path), false);
+    if (!url) {
+        log_msg("error: invalid config path: %s", path);
+        return NULL;
+    }
+
+    CFReadStreamRef stream = CFReadStreamCreateWithFile(kCFAllocatorDefault, url);
+    CFRelease(url);
+    if (!stream || !CFReadStreamOpen(stream)) {
+        log_msg("error: cannot open config file: %s", path);
+        if (stream) CFRelease(stream);
+        return NULL;
+    }
+
+    CFErrorRef error = NULL;
+    CFPropertyListRef plist = CFPropertyListCreateWithStream(
+        kCFAllocatorDefault, stream, 0, kCFPropertyListImmutable, NULL, &error);
+    CFReadStreamClose(stream);
+    CFRelease(stream);
+
+    if (!plist || CFGetTypeID(plist) != CFDictionaryGetTypeID()) {
+        log_msg("error: failed to parse plist config: %s", path);
+        if (error) {
+            CFStringRef desc = CFErrorCopyDescription(error);
+            if (desc) {
+                char buf[256];
+                CFStringGetCString(desc, buf, sizeof(buf), kCFStringEncodingUTF8);
+                log_msg("  detail: %s", buf);
+                CFRelease(desc);
+            }
+            CFRelease(error);
+        }
+        if (plist) CFRelease(plist);
+        return NULL;
+    }
+
+    return (CFDictionaryRef)plist;
+}
+
+/* --- Usage --- */
+
+static void usage(const char *prog)
+{
+    fprintf(stderr, "Usage: %s [options]\n", prog);
+    fprintf(stderr, "  -c <path>   Config plist path (default: %s)\n", DEFAULT_CONFIG_PATH);
+    fprintf(stderr, "  -f          Force apply even if OCLP is not detected\n");
+    fprintf(stderr, "  -n          Dry run (detect OCLP and read config, but don't write SMC)\n");
+    fprintf(stderr, "  -q          Quiet mode (no log file, stderr only)\n");
+    fprintf(stderr, "  -h          Show this help\n");
+}
+
+/* --- Main --- */
+
+int main(int argc, char *argv[])
+{
+    const char *config_path = DEFAULT_CONFIG_PATH;
+    bool force_apply = false;
+    bool dry_run = false;
+    bool quiet = false;
+    int opt;
+
+    while ((opt = getopt(argc, argv, "c:fnqh")) != -1) {
+        switch (opt) {
+            case 'c': config_path = optarg; break;
+            case 'f': force_apply = true; break;
+            case 'n': dry_run = true; break;
+            case 'q': quiet = true; break;
+            case 'h':
+            default:
+                usage(argv[0]);
+                return (opt == 'h') ? 0 : 1;
+        }
+    }
+
+    /* Open log file */
+    if (!quiet) {
+        g_logfile = fopen(LOG_PATH, "a");
+        if (!g_logfile) {
+            fprintf(stderr, "smcfancontrold: warning: cannot open %s for writing\n", LOG_PATH);
+        }
+    }
+
+    log_msg("=== smcfancontrold starting (pid %d) ===", getpid());
+
+    /* Step 1: OCLP detection */
+    int oclp_flags = oclp_detect();
+    char desc_buf[512];
+    oclp_describe(oclp_flags, desc_buf, sizeof(desc_buf));
+    log_msg("%s", desc_buf);
+
+    if (oclp_flags == 0 && !force_apply) {
+        log_msg("Not an OCLP Mac and -f not specified. Exiting without changes.");
+        if (g_logfile) fclose(g_logfile);
+        return 0;
+    }
+
+    if (force_apply && oclp_flags == 0) {
+        log_msg("Force mode: applying fan settings despite no OCLP detection");
+    }
+
+    /* Step 2: Load config */
+    CFDictionaryRef config = load_config(config_path);
+    if (!config) {
+        log_msg("error: no valid config at %s — exiting", config_path);
+        if (g_logfile) fclose(g_logfile);
+        return 1;
+    }
+
+    CFArrayRef fans = CFDictionaryGetValue(config, CFSTR("fans"));
+    if (!fans || CFGetTypeID(fans) != CFArrayGetTypeID()) {
+        log_msg("error: config missing 'fans' array");
+        CFRelease(config);
+        if (g_logfile) fclose(g_logfile);
+        return 1;
+    }
+
+    CFIndex fan_count = CFArrayGetCount(fans);
+    log_msg("config: %ld fan(s) defined", (long)fan_count);
+
+    if (dry_run) {
+        log_msg("dry run mode: skipping SMC writes");
+        for (CFIndex i = 0; i < fan_count; i++) {
+            CFDictionaryRef fan = CFArrayGetValueAtIndex(fans, i);
+            if (!fan || CFGetTypeID(fan) != CFDictionaryGetTypeID()) continue;
+
+            CFNumberRef id_num = CFDictionaryGetValue(fan, CFSTR("id"));
+            CFNumberRef rpm_num = CFDictionaryGetValue(fan, CFSTR("min_rpm"));
+            int fan_id = 0, min_rpm = 0;
+            if (id_num) CFNumberGetValue(id_num, kCFNumberIntType, &fan_id);
+            if (rpm_num) CFNumberGetValue(rpm_num, kCFNumberIntType, &min_rpm);
+            log_msg("  fan %d: would set min RPM to %d", fan_id, min_rpm);
+        }
+        CFRelease(config);
+        log_msg("=== dry run complete ===");
+        if (g_logfile) fclose(g_logfile);
+        return 0;
+    }
+
+    /* Step 3: Open SMC */
+    io_connect_t conn = 0;
+    kern_return_t kr = smc_open(&conn);
+    if (kr != kIOReturnSuccess) {
+        log_msg("error: cannot open SMC connection");
+        CFRelease(config);
+        if (g_logfile) fclose(g_logfile);
+        return 1;
+    }
+
+    /* Step 4: Apply fan settings */
+    static const char fannum[] = "0123456789ABCDEFGHIJ";
+    int errors = 0;
+
+    for (CFIndex i = 0; i < fan_count; i++) {
+        CFDictionaryRef fan = CFArrayGetValueAtIndex(fans, i);
+        if (!fan || CFGetTypeID(fan) != CFDictionaryGetTypeID()) {
+            log_msg("warning: skipping invalid fan entry at index %ld", (long)i);
+            continue;
+        }
+
+        CFNumberRef id_num = CFDictionaryGetValue(fan, CFSTR("id"));
+        CFNumberRef rpm_num = CFDictionaryGetValue(fan, CFSTR("min_rpm"));
+        if (!id_num || !rpm_num) {
+            log_msg("warning: fan entry %ld missing id or min_rpm", (long)i);
+            continue;
+        }
+
+        int fan_id = 0, min_rpm = 0;
+        CFNumberGetValue(id_num, kCFNumberIntType, &fan_id);
+        CFNumberGetValue(rpm_num, kCFNumberIntType, &min_rpm);
+
+        if (fan_id < 0 || fan_id >= MAX_FANS) {
+            log_msg("warning: fan id %d out of range (0-%d)", fan_id, MAX_FANS - 1);
+            continue;
+        }
+        if (min_rpm < 0 || min_rpm > MAX_RPM) {
+            log_msg("warning: min_rpm %d out of range (0-%d)", min_rpm, MAX_RPM);
+            continue;
+        }
+
+        /* Build the F{n}Mn key (fan minimum speed) */
+        char key[5];
+        snprintf(key, sizeof(key), "F%cMn", fannum[fan_id]);
+
+        /* Read current minimum for logging */
+        SMCVal_t cur_val;
+        kr = smc_read(conn, key, &cur_val);
+        if (kr != kIOReturnSuccess) {
+            log_msg("error: cannot read %s (0x%08x)", key, kr);
+            errors++;
+            continue;
+        }
+
+        float current_min = decode_fpe2(cur_val.bytes);
+
+        /* Write new minimum */
+        unsigned char fpe2_bytes[2];
+        encode_fpe2(min_rpm, fpe2_bytes);
+
+        kr = smc_write(conn, key, fpe2_bytes, 2);
+        if (kr != kIOReturnSuccess) {
+            log_msg("error: cannot write %s (0x%08x)", key, kr);
+            errors++;
+            continue;
+        }
+
+        log_msg("fan %d (%s): min RPM %.0f -> %d", fan_id, key, current_min, min_rpm);
+    }
+
+    /* Cleanup */
+    IOServiceClose(conn);
+    CFRelease(config);
+
+    if (errors == 0)
+        log_msg("=== all fans configured successfully ===");
+    else
+        log_msg("=== completed with %d error(s) ===", errors);
+
+    if (g_logfile) fclose(g_logfile);
+    return (errors > 0) ? 1 : 0;
+}

--- a/Readme.md
+++ b/Readme.md
@@ -48,6 +48,35 @@ This fork fixes the clamping behavior so fan speeds are applied reliably regardl
 - **Auto-detect temperature unit** — Celsius or Fahrenheit from system locale, no manual setting
 - **Lightweight** — ~94% smaller than original (Sparkle framework removed)
 
+## OCLP Boot Fan Control
+
+If you're running [OpenCore Legacy Patcher](https://dortania.github.io/OpenCore-Legacy-Patcher/) (OCLP) on an unsupported Mac, fans typically run at 100% from boot until smcFanControl starts — which only happens after you log in.
+
+The **OCLP Boot Fan Daemon** fixes this by applying your saved fan settings at boot, before login. On first launch, smcFanControl auto-detects OCLP and offers to install the daemon.
+
+**How it works:**
+- A small LaunchDaemon (`smcfancontrold`) runs once at boot
+- It reads your saved fan settings from `/Library/Application Support/smcFanControl/fan-settings.plist`
+- It applies fan minimum RPMs via SMC, then exits
+- Settings are synced automatically whenever you adjust fan speeds in the app
+
+**Manual install (advanced):**
+```bash
+cd FanControlHelper
+make
+sudo make install
+# Edit fan settings:
+sudo cp fan-settings-example.plist "/Library/Application Support/smcFanControl/fan-settings.plist"
+```
+
+**Manual uninstall:**
+```bash
+cd FanControlHelper
+sudo make uninstall
+```
+
+See [`FanControlHelper/INTEGRATION.md`](FanControlHelper/INTEGRATION.md) for full technical details.
+
 ## smc CLI
 
 A standalone `smc` binary for reading SMC sensors and fan speeds from the terminal is included in releases. When installing via Homebrew, it is included automatically.


### PR DESCRIPTION
Killer feature for OCLP Mac users: Launch Daemon applies saved fan settings at boot, before login. No more screaming fans on patched Macs.