### PR TITLE
Fix fan speed control + simplify UI

### DIFF
--- a/Classes/FanControl.h
+++ b/Classes/FanControl.h
@@ -144,6 +144,8 @@
 - (void)fanSliderChanged:(id)sender;
 - (void)applyPerFanSettings;
 - (void)updateSliderRPMLabels;
+- (void)setForcedMode:(BOOL)forced forFan:(int)fanIndex;
+- (void)toggleOCLPDaemon:(id)sender;
 - (void)openPreferences:(id)sender;
 @end
 

--- a/Classes/FanControl.m
+++ b/Classes/FanControl.m
@@ -420,6 +420,82 @@ NSUserDefaults *defaults;
         }
     }
 
+    // Hide advanced preferences that aren't needed in the simplified UI.
+    // Keep: Start at login checkbox, menu bar display mode, OCLP toggle.
+    // Hide: auto-change power settings, color selector, fan table, sync checkbox.
+    if (mainwindow) {
+        // Hide the auto-change checkbox and its associated power-source popups
+        if (autochange) [(NSView *)autochange setHidden:YES];
+        if (colorSelector) [(NSView *)colorSelector setHidden:YES];
+        if (syncslider) [(NSView *)syncslider setHidden:YES];
+
+        // Hide the fan table (old per-fan settings table from nib) — replaced by menu sliders
+        NSView *prefContent2 = [(NSWindow *)mainwindow contentView];
+        NSMutableArray *stack2 = [NSMutableArray arrayWithObject:prefContent2];
+        while (stack2.count > 0) {
+            NSView *v = stack2.lastObject;
+            [stack2 removeLastObject];
+            [stack2 addObjectsFromArray:v.subviews];
+
+            // Hide the fan table scroll view
+            if ([v isKindOfClass:[NSScrollView class]]) {
+                NSScrollView *sv = (NSScrollView *)v;
+                // Check if this scroll view contains a table (the fan table)
+                if ([sv.documentView isKindOfClass:[NSTableView class]]) {
+                    [sv setHidden:YES];
+                }
+            }
+
+            // Hide labels related to auto-change power settings
+            if ([v isKindOfClass:[NSTextField class]]) {
+                NSTextField *tf = (NSTextField *)v;
+                NSString *text = [tf stringValue] ?: @"";
+                NSString *lower = [text lowercaseString];
+                if ([lower containsString:@"battery"] ||
+                    [lower containsString:@"batterie"] ||  // German
+                    [lower containsString:@"power source"] ||
+                    [lower containsString:@"charging"] ||
+                    [lower containsString:@"laden"] ||     // German: charging
+                    [lower containsString:@"stromquelle"] || // German: power source
+                    [lower containsString:@"color"] ||
+                    [lower containsString:@"farbe"] ||     // German: color
+                    [lower containsString:@"couleur"]) {   // French: color
+                    [tf setHidden:YES];
+                }
+            }
+
+            // Hide power-source popup buttons (Battery/AC/Charging favorites selectors)
+            if ([v isKindOfClass:[NSPopUpButton class]] && ![v isHidden]) {
+                NSPopUpButton *popup = (NSPopUpButton *)v;
+                // These popups are bound to battery/AC/charging selection prefs
+                for (NSDictionary *binding in @[@{@"key": @"selectedIndex"}]) {
+                    NSDictionary *info = [popup infoForBinding:@"selectedIndex"];
+                    if (info) {
+                        NSString *keyPath = info[NSObservedKeyPathKey] ?: @"";
+                        if ([keyPath containsString:@"selbatt"] ||
+                            [keyPath containsString:@"selac"] ||
+                            [keyPath containsString:@"selload"]) {
+                            [popup setHidden:YES];
+                        }
+                    }
+                }
+            }
+
+            // Hide the "Autoapply favorite when powersource changes" checkbox
+            if ([v isKindOfClass:[NSButton class]]) {
+                NSButton *btn = (NSButton *)v;
+                NSString *title = [[btn title] lowercaseString];
+                if ([title containsString:@"autoapply"] ||
+                    [title containsString:@"powersource"] ||
+                    [title containsString:@"power source"] ||
+                    [title containsString:@"automatisch"] ||  // German
+                    [title containsString:@"stromquelle"]) {  // German
+                    [btn setHidden:YES];
+                }
+            }
+        }
+    }
+
 }
 
 
@@ -517,6 +593,23 @@ NSUserDefaults *defaults;
     // --- Separator ---
     [theMenu addItem:[NSMenuItem separatorItem]];
 
+    // --- OCLP Boot Fan Control toggle (only shown on OCLP Macs) ---
+    if ([OCLPHelper isOCLPMac]) {
+        NSString *oclpTitle = [OCLPHelper isDaemonInstalled]
+            ? @"Boot Fan Control: On"
+            : @"Boot Fan Control: Off";
+        NSMenuItem *oclpItem = [[NSMenuItem alloc]
+            initWithTitle:oclpTitle
+                   action:@selector(toggleOCLPDaemon:)
+            keyEquivalent:@""];
+        [oclpItem setTarget:self];
+        [oclpItem setTag:9999]; // unique tag to find it later
+        if ([OCLPHelper isDaemonInstalled]) {
+            [oclpItem setState:NSOnState];
+        }
+        [theMenu addItem:oclpItem];
+    }
+
     // --- Sleep/Wake Fix... ---
     NSMenuItem *sleepWakeItem = [[NSMenuItem alloc]
         initWithTitle:@"Sleep/Wake Fix..."
@@ -545,6 +638,34 @@ NSUserDefaults *defaults;
     [theMenu addItem:quitItem];
 }
 
+#pragma mark **OCLP Toggle**
+
+/// Toggle the OCLP boot fan control daemon on/off from the menu.
+-(void)toggleOCLPDaemon:(id)sender {
+    NSMenuItem *item = (NSMenuItem *)sender;
+    if ([OCLPHelper isDaemonInstalled]) {
+        // Uninstall
+        BOOL ok = [OCLPHelper uninstallDaemon];
+        if (ok) {
+            [item setTitle:@"Boot Fan Control: Off"];
+            [item setState:NSOffState];
+        }
+    } else {
+        // Install
+        BOOL ok = [OCLPHelper installDaemon];
+        if (ok) {
+            [item setTitle:@"Boot Fan Control: On"];
+            [item setState:NSOnState];
+        } else {
+            NSAlert *alert = [[NSAlert alloc] init];
+            [alert setMessageText:@"Installation Failed"];
+            [alert setInformativeText:@"Could not install the boot fan control daemon. Admin access may be required."];
+            [alert addButtonWithTitle:@"OK"];
+            [alert runModal];
+        }
+    }
+}
+
 #pragma mark **Slider Menu Actions**
 
 /// Called when user drags a fan slider in the menu.
@@ -559,8 +680,24 @@ NSUserDefaults *defaults;
         [label setStringValue:[NSString stringWithFormat:@"%d rpm", newRPM]];
     }
 
-    // Write the new minimum to SMC
     [FanControl setRights];
+
+    // Determine hardware minimum to decide auto vs forced mode
+    int hwMin = [smcWrapper get_min_speed:fanIndex];
+    if (hwMin <= 0) hwMin = 800;
+
+    if (newRPM <= hwMin) {
+        // Return this fan to automatic mode — clear its force bit in FS!
+        [self setForcedMode:NO forFan:fanIndex];
+    } else {
+        // Force this fan to the requested speed
+        [self setForcedMode:YES forFan:fanIndex];
+        // Set target speed (fpe2 encoded)
+        [smcWrapper setKey_external:[NSString stringWithFormat:@"F%dTg", fanIndex]
+                              value:[@(newRPM) tohex]];
+    }
+
+    // Also set the minimum as a floor
     [smcWrapper setKey_external:[NSString stringWithFormat:@"F%dMn", fanIndex]
                           value:[@(newRPM) tohex]];
 
@@ -572,7 +709,34 @@ NSUserDefaults *defaults;
     [OCLPHelper syncFanSettingsWithDaemon];
 }
 
-/// Apply saved per-fan minimum RPM values to SMC (used on launch and wake).
+/// Set or clear forced mode for a specific fan by manipulating the FS!  bitmask.
+-(void)setForcedMode:(BOOL)forced forFan:(int)fanIndex {
+    // Read current FS!  value (ui16 — 2 bytes, big-endian bitmask)
+    // Bit 0 = fan 0, bit 1 = fan 1, etc.
+    // We try the F{n}Md key first (older Macs), fall back to FS!  (newer Macs).
+    int fanMode = [smcWrapper get_mode:fanIndex];
+    if (fanMode >= 0) {
+        // This Mac has per-fan mode keys (F0Md, F1Md, ...)
+        [smcWrapper setKey_external:[NSString stringWithFormat:@"F%dMd", fanIndex]
+                              value:forced ? @"01" : @"00"];
+    } else {
+        // Use the global FS!  bitmask (ui16)
+        // Read current bitmask — we encode it as a 4-hex-digit string
+        // Unfortunately we can't read FS!  easily through smcWrapper (no API for it),
+        // so we maintain a local cache of which fans are forced.
+        static UInt16 sForceBitmask = 0;
+        if (forced) {
+            sForceBitmask |= (1 << fanIndex);
+        } else {
+            sForceBitmask &= ~(1 << fanIndex);
+        }
+        NSString *hexVal = [NSString stringWithFormat:@"%04x", sForceBitmask];
+        [smcWrapper setKey_external:@"FS! " value:hexVal];
+    }
+}
+
+/// Apply saved per-fan RPM values to SMC (used on launch and wake).
+/// Sets both forced mode + target speed (for real control) and minimum floor.
 -(void)applyPerFanSettings {
     [FanControl setRights];
     for (int i = 0; i < g_numFans; i++) {
@@ -585,8 +749,18 @@ NSUserDefaults *defaults;
         int savedRPM = (int)[[NSUserDefaults standardUserDefaults] integerForKey:prefKey];
         if (savedRPM < hwMin || savedRPM > hwMax) savedRPM = hwMin;
 
+        // Set the minimum floor
         [smcWrapper setKey_external:[NSString stringWithFormat:@"F%dMn", i]
                               value:[@(savedRPM) tohex]];
+
+        // If user has set a speed above the hardware minimum, force the fan
+        if (savedRPM > hwMin) {
+            [self setForcedMode:YES forFan:i];
+            [smcWrapper setKey_external:[NSString stringWithFormat:@"F%dTg", i]
+                                  value:[@(savedRPM) tohex]];
+        } else {
+            [self setForcedMode:NO forFan:i];
+        }
 
         // Also update slider position if sliders exist
         if (i < (int)[_fanSliders count]) {
@@ -973,6 +1147,13 @@ NSUserDefaults *defaults;
 -(void)terminate:(id)sender{
 	//get last active selection
 	[defaults synchronize];
+	// Return all fans to automatic mode on quit (unless OCLP daemon will manage them)
+	if (![OCLPHelper isDaemonInstalled]) {
+		[FanControl setRights];
+		for (int i = 0; i < g_numFans; i++) {
+			[self setForcedMode:NO forFan:i];
+		}
+	}
 	[smcWrapper cleanUp];
 	[_readTimer invalidate];
 	[pw deregisterForSleepWakeNotification];
@@ -1071,10 +1252,9 @@ NSUserDefaults *defaults;
         NSLog(@"Error deleting %@",machinesPath);
     }
     error = nil;
-    if ([[MachineDefaults computerModel] rangeOfString:@"MacBookPro15"].location != NSNotFound) {
-        for (int i=0; i<g_numFans; i++) {
-            [smcWrapper setKey_external:[NSString stringWithFormat:@"F%dMd",i] value:@"00"];
-        }
+    // Return all fans to automatic mode on reset
+    for (int i=0; i<g_numFans; i++) {
+        [self setForcedMode:NO forFan:i];
     }
 
     NSString *domainName = [[NSBundle mainBundle] bundleIdentifier];

--- a/FanControlHelper/smcfancontrold.c
+++ b/FanControlHelper/smcfancontrold.c
@@ -388,6 +388,10 @@ int main(int argc, char *argv[])
     static const char fannum[] = "0123456789ABCDEFGHIJ";
     int errors = 0;
 
+    /* Read the hardware minimum speeds first, to know which fans need forced mode.
+     * Build a bitmask for the FS!  key (forced fans). */
+    UInt16 force_bitmask = 0;
+
     for (CFIndex i = 0; i < fan_count; i++) {
         CFDictionaryRef fan = CFArrayGetValueAtIndex(fans, i);
         if (!fan || CFGetTypeID(fan) != CFDictionaryGetTypeID()) {
@@ -415,33 +419,68 @@ int main(int argc, char *argv[])
             continue;
         }
 
-        /* Build the F{n}Mn key (fan minimum speed) */
-        char key[5];
-        snprintf(key, sizeof(key), "F%cMn", fannum[fan_id]);
-
-        /* Read current minimum for logging */
+        /* Read hardware minimum to determine if forced mode is needed */
+        char mn_key[5];
+        snprintf(mn_key, sizeof(mn_key), "F%cMn", fannum[fan_id]);
         SMCVal_t cur_val;
-        kr = smc_read(conn, key, &cur_val);
+        kr = smc_read(conn, mn_key, &cur_val);
         if (kr != kIOReturnSuccess) {
-            log_msg("error: cannot read %s (0x%08x)", key, kr);
+            log_msg("error: cannot read %s (0x%08x)", mn_key, kr);
             errors++;
             continue;
         }
+        float hw_min = decode_fpe2(cur_val.bytes);
 
-        float current_min = decode_fpe2(cur_val.bytes);
-
-        /* Write new minimum */
+        /* Write the minimum speed floor */
         unsigned char fpe2_bytes[2];
         encode_fpe2(min_rpm, fpe2_bytes);
 
-        kr = smc_write(conn, key, fpe2_bytes, 2);
+        kr = smc_write(conn, mn_key, fpe2_bytes, 2);
         if (kr != kIOReturnSuccess) {
-            log_msg("error: cannot write %s (0x%08x)", key, kr);
+            log_msg("error: cannot write %s (0x%08x)", mn_key, kr);
             errors++;
             continue;
         }
 
-        log_msg("fan %d (%s): min RPM %.0f -> %d", fan_id, key, current_min, min_rpm);
+        log_msg("fan %d (%s): min RPM %.0f -> %d", fan_id, mn_key, hw_min, min_rpm);
+
+        /* If the requested speed is above hardware minimum, also set forced mode + target */
+        if (min_rpm > (int)hw_min) {
+            force_bitmask |= (1 << fan_id);
+
+            /* Try per-fan mode key first (older Macs: F{n}Md) */
+            char md_key[5];
+            snprintf(md_key, sizeof(md_key), "F%dMd", fan_id);
+            SMCVal_t md_val;
+            kern_return_t md_kr = smc_read(conn, md_key, &md_val);
+            if (md_kr == kIOReturnSuccess) {
+                unsigned char md_byte = 0x01;  /* forced mode */
+                smc_write(conn, md_key, &md_byte, 1);
+            }
+
+            /* Set target speed */
+            char tg_key[5];
+            snprintf(tg_key, sizeof(tg_key), "F%cTg", fannum[fan_id]);
+            kr = smc_write(conn, tg_key, fpe2_bytes, 2);
+            if (kr == kIOReturnSuccess) {
+                log_msg("fan %d (%s): target RPM set to %d (forced)", fan_id, tg_key, min_rpm);
+            } else {
+                log_msg("warning: cannot write %s (0x%08x)", tg_key, kr);
+            }
+        }
+    }
+
+    /* Write the global force bitmask (FS! ) if any fan is forced */
+    if (force_bitmask != 0) {
+        unsigned char fs_bytes[2];
+        fs_bytes[0] = (force_bitmask >> 8) & 0xFF;
+        fs_bytes[1] = force_bitmask & 0xFF;
+        kr = smc_write(conn, "FS! ", fs_bytes, 2);
+        if (kr == kIOReturnSuccess) {
+            log_msg("FS!  bitmask set to 0x%04x", force_bitmask);
+        } else {
+            log_msg("warning: cannot write FS!  (0x%08x) — per-fan Md keys used as fallback", kr);
+        }
     }
 
     /* Cleanup */


### PR DESCRIPTION
## Summary

- **Fix fan speed slider not actually changing fan speed**: The slider only wrote `F{n}Mn` (minimum floor), which macOS thermal management ignores. Now sets forced mode (via `FS! ` bitmask or `F{n}Md` key) and target speed (`F{n}Tg`) so the slider actually controls fan speed. Sliding to hardware minimum returns the fan to automatic mode.
- **Simplify preferences UI**: Hide fan table, auto-change power settings, color selector, and sync checkbox. Fan control is now entirely through the menu bar sliders.
- **Add OCLP Boot Fan Control toggle** directly in the menu dropdown (only shown on OCLP Macs) for easy on/off.
- **Boot daemon updated** to also use forced mode + target speed, not just minimum floor.

## Technical Details

The SMC fan control model:
- `F{n}Mn` = minimum speed floor (thermal management can override upward)
- `F{n}Tg` = target speed (what the fan should actually spin at)
- `FS! ` = bitmask of which fans are in forced mode (bit 0 = fan 0, etc.)
- `F{n}Md` = per-fan mode key (older Macs only, 0=auto, 1=forced)

Previously only `F{n}Mn` was set, so lowering the slider had no effect when thermal management wanted fans higher. Now the full forced mode + target speed pipeline is used.

## Test plan

- [ ] Build and run on Intel Mac — verify fan sliders in menu actually change fan speed
- [ ] Slide to minimum position — verify fans return to auto mode
- [ ] Slide above minimum — verify fans spin at requested speed
- [ ] Quit app — verify fans return to auto mode (when no OCLP daemon)
- [ ] On OCLP Mac: verify "Boot Fan Control" toggle appears in menu
- [ ] On non-OCLP Mac: verify OCLP toggle is hidden
- [ ] Preferences window: verify favorites, power auto-change, color picker, fan table are hidden
- [ ] Preferences window: verify start-at-login and menu bar style are still visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)