### PR TITLE
update cask name to match tap in homebrew install instructions

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -24,7 +24,7 @@ Works on all OCLP-patched Macs running supported macOS versions.
 
 ```bash
 brew tap wolffcatskyy/tap
-brew install --cask smcfancontrol
+brew install --cask wolffcatskyy/tap/smcfancontrol
 ```
 
 That's it. No Gatekeeper warnings, no right-click tricks.


### PR DESCRIPTION
Though the tap name was updated in a previous commit, `brew install -cask smcfancontrol` will still install v2.6 from the homebrew/core canonical repo's reference to https://github.com/hholtmann/smcFanControl